### PR TITLE
Add an alternate conda environment for running the Python code on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The project is split into two stages:
 
 ## Status
 
-- [X] initialisation produces a snapshot for different study areas
-- [X] basic simulation with the snapshot
-- [ ] commuting (partially ported from Python)
+- [x] initialisation produces a snapshot for different study areas
+- [x] basic simulation with the snapshot
+- [x] commuting
 - [ ] events (partly started)
 - [ ] calibration / validation
 
@@ -33,6 +33,7 @@ One-time installation of things you may be missing:
 
 - The latest version of Rust (1.58): [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install)
 - [Poetry](https://python-poetry.org), for running a fork of the Python model
+  - If you have trouble installing Python dependencies -- especially on Mac M1 -- you can instead use [conda](https://docs.conda.io/projects/conda/en/latest/index.html)
 - The instructions assume you'e running in a shell on Linux or Mac, and have
   standard commands like `unzip` and `python3` available
 
@@ -42,22 +43,13 @@ area:
 ```shell
 git clone https://github.com/dabreegster/rampfs/
 cd rampfs
+# You only have to run this the first time, to install Python dependencies
+poetry install
 # This will take a few minutes the first time you do it, to build external dependencies
 cargo run --release -- init west-yorkshire-small
 ```
 
-If you got an error running cargo, most likely you need to install these two packages.
-
-```
-brew install cmake
-```
-
-```
-brew install proj
-```
-
 This will download some large files the first time. You'll wind up with
-
 `processed_data/WestYorkshireSmall/` as output, as well as lots of intermediate
 files in `raw_data/`. The next time you run this command (even on a different
 study area), it should go much faster. You can run the pipeline for other study
@@ -66,8 +58,6 @@ areas; try `cargo run --release -- init --help` for a list.
 Then to run the snapshot file in the Python model:
 
 ```shell
-# You only have to run this the first time, to install Python dependencies
-poetry install
 poetry run python gui.py -p model_parameters/default.yml
 ```
 
@@ -78,12 +68,33 @@ This should launch an interactive dashboard. Or you can run the simulation in
 poetry run python headless.py -p model_parameters/default.yml
 ```
 
+### Conda alternative
+
+If poetry doesn't work, we also have a Conda environment. You can use it like this:
+
+```shell
+conda env create -f environment.yml
+conda activate aspics
+python3.7 gui.py -p model_parameters/default.yml
+```
+
+Note inside the Conda environment, just `python` may not work; specify `python3.7`.
+
+If you get `CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.` and the provided instructions don't help, on Linux you can try doing `source ~/anaconda3/etc/profile.d/conda.sh`.
+
 ### Troubleshooting
 
 The Rust code depends on [proj](https://proj.org) to transform coordinates. You
 may need to install additional dependencies to build it, like `cmake`. Please
 [open an issue](https://github.com/dabreegster/rampfs/issues) if you have any
 trouble!
+
+On Mac, you can do:
+
+```shell
+brew install cmake
+brew install proj
+```
 
 ## Developer tips
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,20 @@
+name: aspics
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - pandas=1.0.3
+  - click
+  - pyyaml
+  - tqdm
+  - pyopencl=2020.2.2 
+  - pocl
+  - numpy=1.18.5
+  - python=3.7
+  # Conda doesn't have some packages
+  - pip
+  - pip:
+    - imgui==1.4.1 
+    - glfw==1.12.0
+    - PyOpenGL==3.1.5
+    - decorator==4.4.2


### PR DESCRIPTION
I'm testing on Linux right now, and I can't get this working -- as it is, I hit "No compatible device found" trying to start OpenCL, even though the software drivers from `pocl` are installed. If I add `ocl-icd-system`, I get a segfault instead. Everything works fine in conda over in Ramp_UA ecotwins branch, and I haven't figured out the difference here yet.

I won't have access to my Mac till tonight, but I'll try it there then